### PR TITLE
Automated tests for agent

### DIFF
--- a/.github/workflows/python-package-windows.yml
+++ b/.github/workflows/python-package-windows.yml
@@ -23,14 +23,21 @@ jobs:
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
+        # Use x86 python because of https://github.com/kevoreilly/CAPEv2/issues/168
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          architecture: 'x86'
 
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install dependencies
+        run: pip install --upgrade pytest requests
 
-      - name: Run unit tests
+      - name: Run analyzer unit tests
         run: |
           cd analyzer/windows
+          pytest -v .
+
+      - name: Run agent unit tests
+        run: |
+          cd agent
           pytest -v .

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -40,7 +40,7 @@ if sys.version_info[:2] < (3, 6):
 if sys.maxsize > 2**32 and sys.platform == "win32":
     sys.exit("You should install python3 x86! not x64")
 
-AGENT_VERSION = "0.15"
+AGENT_VERSION = "0.16"
 AGENT_FEATURES = [
     "execpy",
     "execute",
@@ -49,6 +49,18 @@ AGENT_FEATURES = [
     "largefile",
     "unicodepath",
 ]
+if sys.platform == "win32":
+    AGENT_FEATURES.append("mutex")
+    MUTEX_TIMEOUT_MS = 500
+    from ctypes import WinError, windll
+
+    kernel32 = windll.kernel32
+    SYNCHRONIZE = 0x100000
+    ERROR_FILE_NOT_FOUND = 0x2
+    WAIT_ABANDONED = 0x00000080
+    WAIT_OBJECT_0 = 0x0
+    WAIT_TIMEOUT = 0x102
+    WAIT_FAILED = 0xFFFFFFFF
 
 
 class Status(enum.IntEnum):
@@ -75,10 +87,13 @@ class Status(enum.IntEnum):
 
 
 ANALYZER_FOLDER = ""
+agent_mutexes = {}
+"""Holds handles of mutexes held by the agent."""
 state = {
     "status": Status.INIT,
     "description": "",
     "async_subprocess": None,
+    "mutexes": agent_mutexes,
 }
 
 
@@ -353,11 +368,89 @@ def get_subprocess_status():
     )
 
 
+def open_mutex(mutex_name):
+    assert sys.platform == "win32"
+    access = SYNCHRONIZE  # only flag the mutex for use
+    inherit_handle = False  # don't pass the handle to children
+    hndl_mutex = kernel32.OpenMutexW(access, inherit_handle, mutex_name)
+    if not hndl_mutex:
+        winerr = WinError()
+        if winerr.errno == ERROR_FILE_NOT_FOUND:
+            return None, json_error(404, "mutex not found")
+        return None, json_error(500, f"error accessing mutex: {winerr}")
+    return hndl_mutex, None
+
+
+def wait_mutex(hndl_mutex):
+    assert sys.platform == "win32"
+    ret = kernel32.WaitForSingleObject(hndl_mutex, MUTEX_TIMEOUT_MS)
+    if ret in (WAIT_ABANDONED, WAIT_OBJECT_0):
+        return True, None
+    elif ret == WAIT_TIMEOUT:
+        return False, json_error(408, "timeout waiting for mutex")
+    elif ret == WAIT_FAILED:
+        # get the extended error information
+        winerr = WinError()
+        return False, json_error(500, f"failed waiting for mutex: {winerr}")
+    else:
+        return False, json_error(500, f"failed waiting for mutex: {ret}")
+
+
+def release_mutex(hndl_mutex):
+    assert sys.platform == "win32"
+    ret = kernel32.ReleaseMutex(hndl_mutex)
+    if not ret:
+        # get the extended error information
+        winerr = WinError()
+        return False, json_error(500, f"failed releasing mutex: {winerr}")
+    return True, None
+
+
 @app.route("/status")
 def get_status():
     if state.get("async_subprocess") is not None:
         return get_subprocess_status()
     return json_success("Analysis status", status=str(state.get("status")), description=state.get("description"))
+
+
+@app.route("/mutex", methods=["POST"])
+def post_mutex():
+    if sys.platform != "win32":
+        return json_error(400, f"mutex feature not supported on {sys.platform}")
+    mutex_name = request.form.get("mutex", "")
+    if not mutex_name:
+        return json_error(400, "no mutex provided")
+    if mutex_name in agent_mutexes:
+        return json_success(f"have mutex: {mutex_name}")
+
+    # does the mutex exist?
+    hndl_mutex, error = open_mutex(mutex_name)
+    if error:
+        return error
+
+    # try waiting on it
+    ok, error = wait_mutex(hndl_mutex)
+    if ok:
+        # save the mutex handle for future requests
+        agent_mutexes[mutex_name] = hndl_mutex
+        return json_success(f"got mutex: {mutex_name}", status_code=201)
+    return error
+
+
+@app.route("/mutex", methods=["DELETE"])
+def delete_mutex():
+    if sys.platform != "win32":
+        return json_error(400, f"mutex feature not supported on {sys.platform}")
+    mutex_name = request.form.get("mutex", "")
+    if not mutex_name:
+        return json_error(400, "no mutex provided")
+    if mutex_name not in agent_mutexes:
+        return json_error(404, f"mutex does not exist: {mutex_name}")
+    hndl_mutex = agent_mutexes.pop(mutex_name)
+    ok, error = release_mutex(hndl_mutex)
+    if ok:
+        return json_success(f"released mutex: {mutex_name}")
+    return error
 
 
 @app.route("/status", methods=["POST"])

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import argparse
+import base64
 import cgi
 import enum
 import http.server
@@ -11,6 +12,7 @@ import json
 import multiprocessing
 import os
 import platform
+import shlex
 import shutil
 import socket
 import socketserver
@@ -38,7 +40,7 @@ if sys.version_info[:2] < (3, 6):
 if sys.maxsize > 2**32 and sys.platform == "win32":
     sys.exit("You should install python3 x86! not x64")
 
-AGENT_VERSION = "0.14"
+AGENT_VERSION = "0.15"
 AGENT_FEATURES = [
     "execpy",
     "execute",
@@ -76,6 +78,7 @@ ANALYZER_FOLDER = ""
 state = {
     "status": Status.INIT,
     "description": "",
+    "async_subprocess": None,
 }
 
 
@@ -112,6 +115,28 @@ class MiniHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
                     request.form[key] = value.value
         self.httpd.handle(self)
 
+    def do_DELETE(self):
+        environ = {
+            "REQUEST_METHOD": "DELETE",
+            "CONTENT_TYPE": self.headers.get("Content-Type"),
+        }
+
+        form = cgi.FieldStorage(fp=self.rfile, headers=self.headers, environ=environ)
+
+        request.client_ip, request.client_port = self.client_address
+        request.form = {}
+        request.files = {}
+        request.method = "DELETE"
+
+        if form.list:
+            for key in form.keys():
+                value = form[key]
+                if value.filename:
+                    request.files[key] = value.file
+                else:
+                    request.form[key] = value.value
+        self.httpd.handle(self)
+
 
 class MiniHTTPServer:
     def __init__(self):
@@ -123,6 +148,7 @@ class MiniHTTPServer:
         self.routes = {
             "GET": [],
             "POST": [],
+            "DELETE": [],
         }
 
     def run(
@@ -170,7 +196,7 @@ class MiniHTTPServer:
         if isinstance(ret, jsonify):
             obj.wfile.write(ret.json().encode())
         elif isinstance(ret, send_file):
-            ret.write(obj.wfile)
+            ret.write(obj, obj.wfile)
 
         if hasattr(self, "s") and self.s._BaseServer__shutdown_request:
             self.close_connection = True
@@ -215,9 +241,10 @@ class jsonify:
 class send_file:
     """Wrapper that represents Flask.send_file functionality."""
 
-    def __init__(self, path):
+    def __init__(self, path, encoding):
         self.path = path
         self.status_code = 200
+        self.encoding = encoding
 
     def init(self):
         if os.path.isfile(self.path) and os.access(self.path, os.R_OK):
@@ -226,15 +253,20 @@ class send_file:
             self.status_code = 404
             self.length = 0
 
-    def write(self, sock):
+    def write(self, httplog, sock):
         if not self.length:
             return
 
-        with open(self.path, "rb") as f:
-            buf = f.read(1024 * 1024)
-            while buf:
-                sock.write(buf)
+        try:
+            with open(self.path, "rb") as f:
                 buf = f.read(1024 * 1024)
+                while buf:
+                    if self.encoding == "base64":
+                        buf = base64.b64encode(buf)
+                    sock.write(buf)
+                    buf = f.read(1024 * 1024)
+        except Exception as ex:
+            httplog.log_error(f"Error reading file {self.path}: {ex}")
 
     def headers(self, obj):
         obj.send_header("Content-Length", self.length)
@@ -269,8 +301,8 @@ def isAdmin():
     return is_admin
 
 
-def json_error(error_code: int, message: str) -> jsonify:
-    r = jsonify(message=message, error_code=error_code)
+def json_error(error_code: int, message: str, **kwargs) -> jsonify:
+    r = jsonify(message=message, error_code=error_code, **kwargs)
     r.status_code = error_code
     return r
 
@@ -281,8 +313,8 @@ def json_exception(message: str) -> jsonify:
     return r
 
 
-def json_success(message: str, **kwargs) -> jsonify:
-    return jsonify(message=message, **kwargs)
+def json_success(message: str, status_code=200, **kwargs) -> jsonify:
+    return jsonify(message=message, status_code=status_code, **kwargs)
 
 
 @app.route("/")
@@ -291,8 +323,40 @@ def get_index():
     return json_success("CAPE Agent!", version=AGENT_VERSION, features=AGENT_FEATURES, is_user_admin=bool(is_admin))
 
 
+def get_subprocess_status():
+    """Return the subprocess status."""
+    async_subprocess = state.get("async_subprocess")
+    message = "Analysis status"
+    exitcode = async_subprocess.exitcode
+    if exitcode is None or (sys.platform == "win32" and exitcode == 259):
+        # Process is still running.
+        state["status"] = Status.RUNNING
+        return json_success(
+            message=message,
+            status=str(state.get("status")),
+            description=state.get("description"),
+            process_id=async_subprocess.pid,
+        )
+    # Process completed; reset async subprocess state.
+    state["async_subprocess"] = None
+    if exitcode == 0:
+        state["status"] = Status.COMPLETE
+        state["description"] = ""
+    else:
+        state["status"] = Status.FAILED
+        state["description"] = f"Exited with exit code {exitcode}"
+    return json_success(
+        message=message,
+        status=str(state.get("status")),
+        description=state.get("description"),
+        exitcode=exitcode,
+    )
+
+
 @app.route("/status")
 def get_status():
+    if state.get("async_subprocess") is not None:
+        return get_subprocess_status()
     return json_success("Analysis status", status=str(state.get("status")), description=state.get("description"))
 
 
@@ -339,11 +403,12 @@ def do_mkdir():
     if "dirpath" not in request.form:
         return json_error(400, "No dirpath has been provided")
 
-    mode = int(request.form.get("mode", 0o777))
-
     try:
+        mode = int(request.form.get("mode", 0o777))
+
         os.makedirs(request.form["dirpath"], mode=mode)
-    except Exception:
+    except Exception as ex:
+        print(f"error creating dir {ex}")
         return json_exception("Error creating directory")
 
     return json_success("Successfully created directory")
@@ -390,8 +455,8 @@ def do_store():
     try:
         with open(request.form["filepath"], "wb") as f:
             shutil.copyfileobj(request.files["file"], f, 10 * 1024 * 1024)
-    except Exception:
-        return json_exception("Error storing file")
+    except Exception as ex:
+        return json_exception(f"Error storing file: {ex}")
 
     return json_success("Successfully stored file")
 
@@ -401,7 +466,7 @@ def do_retrieve():
     if "filepath" not in request.form:
         return json_error(400, "No filepath has been provided")
 
-    return send_file(request.form["filepath"])
+    return send_file(request.form["filepath"], request.form.get("encoding", ""))
 
 
 @app.route("/extract", methods=["POST"])
@@ -415,8 +480,8 @@ def do_extract():
     try:
         with ZipFile(request.files["zipfile"], "r") as archive:
             archive.extractall(request.form["dirpath"])
-    except Exception:
-        return json_exception("Error extracting zip file")
+    except Exception as ex:
+        return json_exception(f"Error extracting zip file {ex}")
 
     return json_success("Successfully extracted zip file")
 
@@ -453,6 +518,7 @@ def do_execute():
 
     if "command" not in request.form:
         return json_error(400, "No command has been provided")
+    command_to_execute = shlex.split(request.form["command"])
 
     # only allow date command from localhost. Even this is just to
     # let it be tested
@@ -469,18 +535,62 @@ def do_execute():
 
     try:
         if async_exec:
-            subprocess.Popen(request.form["command"], shell=shell, cwd=cwd)
+            subprocess.Popen(command_to_execute, shell=shell, cwd=cwd)
         else:
-            p = subprocess.Popen(request.form["command"], shell=shell, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen(command_to_execute, shell=shell, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
-    except Exception:
+            if request.form.get("encoding", "") == "base64":
+                stdout = base64.b64encode(stdout)
+                stderr = base64.b64encode(stderr)
+    except Exception as ex:
         state["status"] = Status.FAILED
         state["description"] = "Error execute command"
-        return json_exception("Error executing command")
+        return json_exception(f"Error executing command: {ex}")
 
     state["status"] = Status.RUNNING
     state["description"] = ""
     return json_success("Successfully executed command", stdout=stdout, stderr=stderr)
+
+
+def run_subprocess(command_args, cwd, base64_encode, shell=False):
+    """Execute the subprocess, wait for completion.
+
+    Return the exitcode (returncode), the stdout, and the stderr.
+    """
+    p = subprocess.Popen(
+        args=command_args,
+        cwd=cwd,
+        shell=shell,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = p.communicate()
+    if base64_encode:
+        stdout = base64.b64encode(stdout)
+        stderr = base64.b64encode(stderr)
+    return p.returncode, stdout, stderr
+
+
+def background_subprocess(command_args, cwd, base64_encode, shell=False):
+    """Run subprocess, wait for completion, then exit.
+
+    This process must exit, so the parent process (agent) can find the exit status."""
+    # TODO: return the stdout/stderr to the parent process.
+    returncode, stdout, stderr = run_subprocess(command_args, cwd, base64_encode, shell)
+    sys.stdout.write(stdout.decode("ascii"))
+    sys.stderr.write(stderr.decode("ascii"))
+    sys.exit(returncode)
+
+
+def spawn(args, cwd, base64_encode, shell=False):
+    """Kick off a subprocess in the background."""
+    run_subprocess_args = [args, cwd, base64_encode, shell]
+    proc = multiprocessing.Process(target=background_subprocess, name=f"child process {args[1]}", args=run_subprocess_args)
+    proc.start()
+    state["status"] = Status.RUNNING
+    state["description"] = ""
+    state["async_subprocess"] = proc
+    return json_success("Successfully spawned command", process_id=proc.pid)
 
 
 @app.route("/execpy", methods=["POST"])
@@ -490,28 +600,34 @@ def do_execpy():
 
     # Execute the command asynchronously? As a shell command?
     async_exec = "async" in request.form
+    base64_encode = request.form.get("encoding", "") == "base64"
 
     cwd = request.form.get("cwd")
-    stdout = stderr = None
 
     args = (
         sys.executable,
         request.form["filepath"],
     )
 
+    if async_exec and state["status"] == Status.RUNNING and state["async_subprocess"]:
+        return json_error(400, "Async process already running.")
     try:
         if async_exec:
-            subprocess.Popen(args, cwd=cwd)
-        else:
-            p = subprocess.Popen(args, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate()
-    except Exception:
+            return spawn(args, cwd, base64_encode)
+        exitcode, stdout, stderr = run_subprocess(args, cwd, base64_encode)
+        if exitcode == 0:
+            state["status"] = Status.COMPLETE
+            state["description"] = ""
+            return json_success("Successfully executed command", stdout=stdout, stderr=stderr)
+        # Process exited with non-zero result.
         state["status"] = Status.FAILED
-        state["description"] = "Error executing command"
-        return json_exception("Error executing command")
-
-    state["status"] = Status.RUNNING
-    return json_success("Successfully executed command", stdout=stdout, stderr=stderr)
+        message = "Error executing python command."
+        state["description"] = message
+        return json_error(400, message, stdout=stdout, stderr=stderr, exitcode=exitcode)
+    except Exception as ex:
+        state["status"] = Status.FAILED
+        state["description"] = "Error executing Python command"
+        return json_exception(f"Error executing Python command: {ex}")
 
 
 @app.route("/pinning")

--- a/agent/pytest.ini
+++ b/agent/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+asyncio_mode = auto

--- a/agent/test_agent.py
+++ b/agent/test_agent.py
@@ -1,0 +1,479 @@
+"""Tests for the agent."""
+
+import datetime
+import io
+import multiprocessing
+import os
+import pathlib
+import random
+import shutil
+import sys
+import tempfile
+import uuid
+import zipfile
+from urllib.parse import urljoin
+
+import pytest
+import requests
+
+import agent
+
+HOST = "127.0.0.1"
+PORT = 8000
+BASE_URL = f"http://{HOST}:{PORT}"
+
+DIRPATH = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
+
+
+def make_temp_name():
+    return str(uuid.uuid4())
+
+
+class TestAgent:
+    """Test the agent API."""
+
+    agent_process: multiprocessing.Process = None
+
+    def setup_method(self):
+        agent.state = {"status": agent.STATUS_INIT, "description": "", "async_subprocess": None}
+        ev = multiprocessing.Event()
+        self.agent_process = multiprocessing.Process(
+            target=agent.app.run,
+            kwargs={"host": HOST, "port": PORT, "event": ev},
+        )
+        self.agent_process.start()
+
+        # Wait for http server to start.
+        if not ev.wait(5.0):
+            raise Exception("Failed to start agent HTTP server")
+
+        # Create temp directory for tests, as makes tidying up easier
+        os.mkdir(DIRPATH, 0o777)
+        assert os.path.isdir(DIRPATH)
+
+    def teardown_method(self):
+        # Remove the temporary directory and files.
+        try:
+            # Test the kill endpoint, which shuts down the agent service.
+            r = requests.get(f"{BASE_URL}/kill")
+            assert r.status_code == 200
+            assert r.json()["message"] == "Quit the CAPE Agent"
+        except requests.exceptions.ConnectionError:
+            pass
+        shutil.rmtree(DIRPATH, ignore_errors=True)
+        assert not os.path.isdir(DIRPATH)
+
+        # Ensure agent process completes; release resources.
+        self.agent_process.join()
+        self.agent_process.close()
+
+    @staticmethod
+    def non_existent_directory():
+        root = pathlib.Path(tempfile.gettempdir()).root
+        current_pid = os.getpid()
+        non_existent = pathlib.Path(root, str(current_pid), str(random.randint(10000, 99999)))
+        assert not os.path.isdir(non_existent)
+        assert not os.path.exists(non_existent)
+        return non_existent
+
+    @staticmethod
+    def confirm_status(expected_status):
+        """Do a get and check the status."""
+        status_url = urljoin(BASE_URL, "status")
+        r = requests.get(status_url)
+        js = r.json()
+        assert js["message"] == "Analysis status"
+        assert js["status"] == expected_status
+        assert r.status_code == 200
+        return js
+
+    @staticmethod
+    def create_file(path, contents):
+        """Create the named file with the supplied contents."""
+        with open(path, "w") as file:
+            file.write(contents)
+        assert os.path.exists(path)
+        assert os.path.isfile(path)
+
+    @staticmethod
+    def file_contains(path, expected_contents):
+        """Examine the contents of a file."""
+        with open(path) as file:
+            actual_contents = file.read()
+            return bool(expected_contents in actual_contents)
+
+    @classmethod
+    def store_file(cls, file_contents):
+        """Store a file via the API, with the given contents. Return the filepath."""
+        contents = os.linesep.join(file_contents)
+        upload_file = {"file": ("name-here-matters-not", contents)}
+        filepath = os.path.join(DIRPATH, make_temp_name() + ".py")
+        form = {"filepath": filepath}
+        js = cls.post_form("store", form, files=upload_file)
+        assert js["message"] == "Successfully stored file"
+        assert os.path.isfile(filepath)
+        assert cls.file_contains(filepath, file_contents[0])
+        assert cls.file_contains(filepath, file_contents[-1])
+        return filepath
+
+    @staticmethod
+    def post_form(url_part, form_data, expected_status=200, files=None):
+        """Post to the URL and return the json."""
+        url = urljoin(BASE_URL, url_part)
+        r = requests.post(url, data=form_data, files=files)
+        assert r.status_code == expected_status
+        js = r.json()
+        return js
+
+    def test_root(self):
+        r = requests.get(f"{BASE_URL}/")
+        assert r.status_code == 200
+        js = r.json()
+        assert js["message"] == "CAPE Agent!"
+        assert "version" in js
+        assert "features" in js
+        assert "execute" in js["features"]
+        assert "execpy" in js["features"]
+        assert "pinning" in js["features"]
+
+    def test_status_write_valid_text(self):
+        """Write a status of 'exception'."""
+        # First, confirm the status is NOT 'exception'.
+        _ = self.confirm_status(agent.STATUS_INIT)
+        form = {"status": "exception"}
+        url_part = "status"
+        _ = self.post_form(url_part, form)
+        _ = self.confirm_status("exception")
+
+    def test_status_write_invalid(self):
+        """Fail to provide a valid status."""
+        form = {"description": "Test Status"}
+        js = self.post_form("status", form, 400)
+        assert js["message"] == "No status has been provided"
+
+        form = {"status": "unexpected value"}
+        js = self.post_form("status", form, 200)
+        assert js["message"] == "Analysis status updated"
+        _ = self.confirm_status("unexpected value")
+
+        # Write an unexpected random number.
+        form = {"status": random.randint(50, 99)}
+        js = self.post_form("status", form, 200)
+        assert js["message"] == "Analysis status updated"
+        _ = self.confirm_status(str(form["status"]))
+
+    def test_logs(self):
+        """Test that the agent responds to a request for the logs."""
+        r = requests.get(f"{BASE_URL}/logs")
+        assert r.status_code == 200
+        js = r.json()
+        assert js["message"] == "Agent logs"
+        assert "stdout" in js
+        assert "stderr" in js
+
+    def test_system(self):
+        """Test that the agent responds to a request for the system/platform."""
+        r = requests.get(f"{BASE_URL}/system")
+        assert r.status_code == 200
+        js = r.json()
+        assert js["message"] == "System"
+        assert "system" in js
+        if sys.platform == "win32":
+            assert js["system"] == "Windows"
+        else:
+            assert js["system"] == "Linux"
+
+    def test_environ(self):
+        """Test that the agent responds to a request for the environment."""
+        r = requests.get(f"{BASE_URL}/environ")
+        assert r.status_code == 200
+        js = r.json()
+        assert js["message"] == "Environment variables"
+        assert "environ" in js
+
+    def test_path(self):
+        """Test that the agent responds to a request for its path."""
+        r = requests.get(f"{BASE_URL}/path")
+        assert r.status_code == 200
+        js = r.json()
+        assert js["message"] == "Agent path"
+        assert "filepath" in js
+        assert os.path.isfile(js["filepath"])
+
+    def test_mkdir_valid(self):
+        """Test that the agent creates a directory."""
+        new_dir = os.path.join(DIRPATH, make_temp_name())
+        form = {
+            "dirpath": new_dir,
+            "mode": 0o777,
+        }
+        js = self.post_form("mkdir", form)
+        assert js["message"] == "Successfully created directory"
+        assert os.path.exists(new_dir)
+        assert os.path.isdir(new_dir)
+
+    def test_mkdir_invalid(self):
+        """Ensure we get an error returned when the mkdir request fails."""
+        form = {}
+        js = self.post_form("mkdir", form, 400)
+        assert js["message"] == "No dirpath has been provided"
+
+        root = pathlib.Path(tempfile.gettempdir()).root
+        form = {"dirpath": root, "mode": 0o777}
+        js = self.post_form("mkdir", form, 500)
+        assert js["message"] == "Error creating directory"
+
+    def test_mktemp_valid(self):
+        form = {
+            "dirpath": DIRPATH,
+            "prefix": make_temp_name(),
+            "suffix": "tmp",
+        }
+        js = self.post_form("mktemp", form)
+        assert js["message"] == "Successfully created temporary file"
+        # tempfile.mkstemp adds random characters to suffix, so returned name
+        # will be different
+        assert "filepath" in js and js["filepath"].startswith(os.path.join(form["dirpath"], form["prefix"]))
+        assert os.path.exists(js["filepath"])
+        assert os.path.isfile(js["filepath"])
+
+    def test_mktemp_invalid(self):
+        """Ensure we get an error returned when the mktemp request fails."""
+        dirpath = self.non_existent_directory()
+        form = {
+            "dirpath": dirpath,
+            "prefix": "",
+            "suffix": "",
+        }
+        js = self.post_form("mktemp", form, 500)
+        assert js["message"] == "Error creating temporary file"
+
+    def test_mkdtemp_valid(self):
+        """Ensure we can use the mkdtemp endpoint."""
+        form = {
+            "dirpath": DIRPATH,
+            "prefix": make_temp_name(),
+            "suffix": "tmp",
+        }
+        js = self.post_form("mkdtemp", form)
+        assert js["message"] == "Successfully created temporary directory"
+        # tempfile.mkdtemp adds random characters to suffix, so returned name
+        # will be different
+        assert "dirpath" in js and js["dirpath"].startswith(os.path.join(form["dirpath"], form["prefix"]))
+        assert os.path.exists(js["dirpath"])
+        assert os.path.isdir(js["dirpath"])
+
+    def test_mkdtemp_invalid(self):
+        """Ensure we get an error returned when the mkdtemp request fails."""
+        dirpath = self.non_existent_directory()
+        assert not dirpath.exists()
+        form = {
+            "dirpath": dirpath,
+            "prefix": "",
+            "suffix": "",
+        }
+        js = self.post_form("mkdtemp", form, 500)
+        assert js["message"] == "Error creating temporary directory"
+
+    def test_store(self):
+        sample_text = make_temp_name()
+        upload_file = {"file": ("ignored", os.linesep.join(("test data", sample_text, "test data")))}
+        form = {"filepath": os.path.join(DIRPATH, make_temp_name() + ".tmp")}
+
+        js = self.post_form("store", form, files=upload_file)
+        assert js["message"] == "Successfully stored file"
+        assert os.path.exists(form["filepath"])
+        assert os.path.isfile(form["filepath"])
+        assert self.file_contains(form["filepath"], sample_text)
+
+    def test_store_invalid(self):
+        # missing file
+        form = {"filepath": os.path.join(DIRPATH, make_temp_name() + ".tmp")}
+        js = self.post_form("store", form, 400)
+        assert js["message"] == "No file has been provided"
+
+        # missing filepath
+        upload_file = {"file": ("test_data.txt", "test data\ntest data\n")}
+        js = self.post_form("store", {}, 400, files=upload_file)
+        assert js["message"] == "No filepath has been provided"
+
+        # destination file path is invalid
+        upload_file = {"file": ("test_data.txt", "test data\ntest data\n")}
+        form = {"filepath": os.path.join(DIRPATH, make_temp_name(), "tmp")}
+        js = self.post_form("store", form, 500, files=upload_file)
+        assert js["message"] == "Error storing file"
+
+    def test_retrieve(self):
+        """Create a file, then try to retrieve it."""
+        first_line = make_temp_name()
+        last_line = make_temp_name()
+        file_contents = os.linesep.join((first_line, "test data", last_line))
+        file_path = os.path.join(DIRPATH, make_temp_name() + ".tmp")
+        self.create_file(file_path, file_contents)
+
+        form = {"filepath": file_path}
+        # Can't use self.post_form here as no json will be returned.
+        r = requests.post(f"{BASE_URL}/retrieve", data=form)
+        assert r.status_code == 200
+        assert first_line in r.text
+        assert last_line in r.text
+
+    def test_retrieve_invalid(self):
+        js = self.post_form("retrieve", {}, 400)
+        assert js["message"].startswith("No filepath has been provided")
+
+        # request to retrieve non existent file
+        form = {"filepath": os.path.join(DIRPATH, make_temp_name() + ".tmp")}
+        # Can't use self.post_form here as no json will be returned.
+        r = requests.post(f"{BASE_URL}/retrieve", data=form)
+        assert r.status_code == 404
+
+    def test_extract(self):
+        """Create a file zip file, then upload and extract the contents."""
+        file_dir = make_temp_name()
+        file_name = make_temp_name()
+        file_contents = make_temp_name()
+        zfile = io.BytesIO()
+        zf = zipfile.ZipFile(zfile, "w", zipfile.ZIP_DEFLATED, False)
+        zf.writestr(os.path.join(file_dir, file_name), file_contents)
+        zf.close()
+        zfile.seek(0)
+
+        upload_file = {"zipfile": ("test_file.zip", zfile.read())}
+        form = {"dirpath": DIRPATH}
+
+        js = self.post_form("extract", form, files=upload_file)
+        assert js["message"] == "Successfully extracted zip file"
+        expected_path = os.path.join(DIRPATH, file_dir, file_name)
+        assert os.path.exists(expected_path)
+        assert self.file_contains(expected_path, file_contents)
+
+        # todo should I check the filesytem for the file?
+
+    def test_extract_invalid(self):
+        form = {"dirpath": DIRPATH}
+        js = self.post_form("extract", form, 400)
+        assert js["message"] == "No zip file has been provided"
+
+        upload_file = {"zipfile": ("test_file.zip", "dummy data")}
+        js = self.post_form("extract", {}, 400, files=upload_file)
+        assert js["message"] == "No dirpath has been provided"
+
+    def test_remove(self):
+        tempdir = os.path.join(DIRPATH, make_temp_name())
+        tempfile = os.path.join(tempdir, make_temp_name())
+        os.mkdir(tempdir, 0o777)
+        self.create_file(tempfile, "test data\ntest data\n")
+
+        # delete temp file
+        form = {"path": tempfile}
+        js = self.post_form("remove", form)
+        assert js["message"] == "Successfully deleted file"
+
+        # delete temp directory
+        form = {"path": tempdir}
+        js = self.post_form("remove", form)
+        assert js["message"] == "Successfully deleted directory"
+
+    def test_remove_invalid(self):
+        tempdir = os.path.join(DIRPATH, make_temp_name())
+
+        # missing parameter
+        form = {}
+        js = self.post_form("remove", form, 400)
+        assert js["message"] == "No path has been provided"
+
+        # path doesn't exist
+        form = {"path": tempdir}
+        js = self.post_form("remove", form, 404)
+        assert js["message"] == "Path provided does not exist"
+
+    @pytest.mark.skipif(agent.isAdmin(), reason="Test fails if privileges are elevated.")
+    def test_remove_system_temp_dir(self):
+        # error removing file or dir (permission)
+        form = {"path": tempfile.gettempdir()}
+        js = self.post_form("remove", form, 500)
+        assert js["message"] == "Error removing file or directory"
+
+    def test_execute(self):
+        """Test executing the 'date' command."""
+        if sys.platform == "win32":
+            form = {"command": "cmd /c date /t"}
+        else:
+            form = {"command": "date"}
+        js = self.post_form("execute", form)
+        assert js["message"] == "Successfully executed command"
+        assert "stdout" in js
+        assert "stderr" in js
+        current_year = datetime.date.today().isoformat()
+        assert current_year[:4] in js["stdout"]
+
+    def test_execute_error(self):
+        """Expect an error on invalid command to execute."""
+        js = self.post_form("execute", {}, 400)
+        assert js["message"] == "No command has been provided"
+
+        form = {"command": "ls"}
+        js = self.post_form("execute", form, 500)
+        assert js["message"] == "Not allowed to execute commands"
+
+    def test_execute_py(self):
+        """Test we can execute a simple python script."""
+        # The output line endings are different between linux and Windows.
+        file_contents = (
+            f"# Comment a random number {random.randint(1000, 9999)}'",
+            "import sys",
+            "print('hello world')",
+            "print('goodbye world', file=sys.stderr)",
+        )
+        filepath = self.store_file(file_contents)
+
+        form = {"filepath": filepath}
+        js = self.post_form("execpy", form)
+        assert js["message"] == "Successfully executed command"
+        assert "stdout" in js and "hello world" in js["stdout"]
+        assert "stderr" in js and "goodbye world" in js["stderr"]
+
+    def test_execute_py_error_no_file(self):
+        """Ensure we get a 400 back when there's no file provided."""
+        # The agent used to return 200 even in various failure scenarios.
+        js = self.post_form("execpy", {}, expected_status=400)
+        assert js["message"] == "No Python file has been provided"
+
+    def test_execute_py_error_nonexistent_file(self):
+        """Ensure we get a 400 back when a nonexistent filename is provided."""
+        filepath = os.path.join(DIRPATH, make_temp_name() + ".py")
+        form = {"filepath": filepath}
+        js = self.post_form("execpy", form, expected_status=200)
+        assert js["message"] == "Successfully executed command"
+        assert "stderr" in js and "No such file or directory" in js["stderr"]
+        _ = self.confirm_status(agent.STATUS_RUNNING)
+
+    def test_execute_py_error_non_zero_exit_code(self):
+        """Ensure we get a 400 back when there's a non-zero exit code."""
+        # Run a python script that exits non-zero.
+        file_contents = (
+            f"# Comment a random number {random.randint(1000, 9999)}'",
+            "import sys",
+            "print('hello world')",
+            "sys.exit(3)",
+        )
+        filepath = self.store_file(file_contents)
+        form = {"filepath": filepath}
+        js = self.post_form("execpy", form, expected_status=200)
+        assert js["message"] == "Successfully executed command"
+        assert "hello world" in js["stdout"]
+        _ = self.confirm_status(agent.STATUS_RUNNING)
+
+    def test_pinning(self):
+        r = requests.get(f"{BASE_URL}/pinning")
+        assert r.status_code == 200
+        js = r.json()
+        assert js["message"] == "Successfully pinned Agent"
+        assert "client_ip" in js
+
+        # Pinning again causes an error.
+        r = requests.get(f"{BASE_URL}/pinning")
+        assert r.status_code == 500
+        js = r.json()
+        assert js["message"] == "Agent has already been pinned to an IP!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ exclude = ".git,__pycache__,.cache,.venv"
 django_find_project = false
 DJANGO_SETTINGS_MODULE = "web.settings"
 pythonpath = [".", "web"]
-testpaths = "tests"
+testpaths = ["tests", "agent"]
 norecursedirs = "tests/zip_compound"
 
 [build-system]


### PR DESCRIPTION
Agent version 13. Unit tests for agent
==
- Added file test_agent.py
- Tests can be run in Windows or Linux
- Tests will be run in github actions
- Test most existing functionality of the agent
- In send_file open the file in binary mode (bug fix)
- Updates to the agent to make it testable, including:
  - Pass a multiprocessing event to the run() method when under test, so the test knows when the agent process is ready
  - Tweaks to the shutdown method enabling testing
- Let jsonify not crash if values cannot be serialized
- Add a new command-line parameter, -v, useful when testing interactively
  - When -v is given, stdout and stderr will simply go to the console
- Allow the 'date' command to be executed from localhost; for testing

Agent version 14. Stricter setting of agent status
==
- Use an enum for the status. Only accept expected values.
- Check that we can read a file before trying to send it.

Agent version 15. Monitor a background process
==

- Monitor async python process spawned in background
  - Be able to detect if background process completed ok or errored
- Accurately report failure status on execution failures
  - The agent used to report RUNNING when the process actually FAILED
- Add base64 encoding capability to send_file
- Detect and log errors that occur during send_file
- Add DELETE capability to the HTTPRequestHandler
  - This gives us the option of adding DELETE methods in future
- Allow json_success to have status codes
- Allow json_error to accept kwargs, like json_success already does
- More detailed error messages for certain kinds of failure
  - creating directory; storing file; extracting zip file

Agent version 16. Added support for obtaining and releasing mutexes
==

- Via a POST request, the agent will now grab a named mutex from the kernel
  - If not immediately available, wait 500 ms
- Via a DELETE request, the agent will release the named mutex